### PR TITLE
Fix Block:Tx:Output unmarshalling

### DIFF
--- a/model_output.go
+++ b/model_output.go
@@ -43,8 +43,7 @@ func (dst *Output) UnmarshalJSON(data []byte) error {
 	// try to unmarshal data into AssetOutput
 	err = newStrictDecoder(data).Decode(&dst.AssetOutput)
 	if err == nil {
-		jsonAssetOutput, _ := json.Marshal(dst.AssetOutput)
-		if string(jsonAssetOutput) == "{}" { // empty struct
+		if dst.AssetOutput == nil || dst.AssetOutput.Type != "AssetOutput" { // not the right type
 			dst.AssetOutput = nil
 		} else {
 			match++
@@ -56,8 +55,7 @@ func (dst *Output) UnmarshalJSON(data []byte) error {
 	// try to unmarshal data into ContractOutput
 	err = newStrictDecoder(data).Decode(&dst.ContractOutput)
 	if err == nil {
-		jsonContractOutput, _ := json.Marshal(dst.ContractOutput)
-		if string(jsonContractOutput) == "{}" { // empty struct
+		if dst.ContractOutput == nil || dst.ContractOutput.Type != "ContractOutput" { // not the right type
 			dst.ContractOutput = nil
 		} else {
 			match++

--- a/model_output_test.go
+++ b/model_output_test.go
@@ -1,0 +1,66 @@
+package alephium
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalModel(t *testing.T) {
+
+	// Tx https://explorer-v112.testnet.alephium.org/transactions/d78e6b405f1e7239f660e11f08e9b20775dab396f617673e341ef1c41596167f
+	// is causing some unmarshalling error: "data matches more than one schema in oneOf(Output)"
+	tests := []struct {
+		data   []byte
+		result Output
+	}{
+		{
+			data: []byte(`{
+			   "type": "ContractOutput",
+			   "hint": 905276618,
+			   "key": "e68624d324aba3cfbb84c1edab5167ba167244c2bc40bae33b1941645a75a93e",
+			   "attoAlphAmount": "1000000000000000000",
+			   "address": "2ACpX9pgDSSVAbBZJrNXcDUW7woxfjsvwYk6EKmEmswy9",
+			   "tokens": []
+			 }`),
+			result: Output{ContractOutput: &ContractOutput{
+				Type:           "ContractOutput",
+				Hint:           905276618,
+				Key:            "e68624d324aba3cfbb84c1edab5167ba167244c2bc40bae33b1941645a75a93e",
+				AttoAlphAmount: "1000000000000000000",
+				Address:        "2ACpX9pgDSSVAbBZJrNXcDUW7woxfjsvwYk6EKmEmswy9",
+				Tokens:         []Token{},
+			}},
+		},
+		{
+			data: []byte(`{
+				   "type": "AssetOutput",
+				   "hint": 933512263,
+				   "key": "68f87e99a2396a31e814f926f11c75cfbd5a44515c0ee496ca48c85c31d7d476",
+				   "attoAlphAmount": "1992242400000000000",
+				   "address": "1DrDyTr9RpRsQnDnXo2YRiPzPW4ooHX5LLoqXrqfMrpQH",
+				   "tokens": [],
+				   "lockTime": 0,
+				   "message": ""
+				 }`),
+			result: Output{AssetOutput: &AssetOutput{
+				Type:           "AssetOutput",
+				Hint:           933512263,
+				Key:            "68f87e99a2396a31e814f926f11c75cfbd5a44515c0ee496ca48c85c31d7d476",
+				AttoAlphAmount: "1992242400000000000",
+				Address:        "1DrDyTr9RpRsQnDnXo2YRiPzPW4ooHX5LLoqXrqfMrpQH",
+				Tokens:         []Token{},
+				LockTime:       0,
+				Message:        "",
+			}},
+		},
+	}
+
+	for _, c := range tests {
+		var v Output
+		err := json.Unmarshal(c.data, &v)
+		assert.Nil(t, err)
+		assert.Equal(t, v, c.result)
+	}
+}


### PR DESCRIPTION
Tx https://explorer-v112.testnet.alephium.org/transactions/d78e6b405f1e7239f660e11f08e9b20775dab396f617673e341ef1c41596167f from block https://explorer-v112.testnet.alephium.org/blocks/0000004377b143992acdb4445aaf5e4de0a919d92a2d3da5435900a185681070 is throwing an unmarshalling error "data matches more than one schema in oneOf(Output)" when fetching the block via the blockflow/block API endpoint as well as the transaction via transactions/$txid API endpoint.
This PR fixes the unmarshalling of the problematic Output element.