### PR TITLE
Fix all the unmarshalling issue with oneOf pattern

### DIFF
--- a/model_discovery_action.go
+++ b/model_discovery_action.go
@@ -43,8 +43,7 @@ func (dst *DiscoveryAction) UnmarshalJSON(data []byte) error {
 	// try to unmarshal data into Reachable
 	err = newStrictDecoder(data).Decode(&dst.Reachable)
 	if err == nil {
-		jsonReachable, _ := json.Marshal(dst.Reachable)
-		if string(jsonReachable) == "{}" { // empty struct
+		if dst.Reachable == nil || dst.Reachable.Type != "Reachable" { // not the right type
 			dst.Reachable = nil
 		} else {
 			match++
@@ -56,8 +55,7 @@ func (dst *DiscoveryAction) UnmarshalJSON(data []byte) error {
 	// try to unmarshal data into Unreachable
 	err = newStrictDecoder(data).Decode(&dst.Unreachable)
 	if err == nil {
-		jsonUnreachable, _ := json.Marshal(dst.Unreachable)
-		if string(jsonUnreachable) == "{}" { // empty struct
+		if dst.Unreachable == nil || dst.Unreachable.Type != "Unreachable" { // not the right type
 			dst.Unreachable = nil
 		} else {
 			match++

--- a/model_discovery_action_test.go
+++ b/model_discovery_action_test.go
@@ -1,0 +1,44 @@
+package alephium
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalDiscoveryAction(t *testing.T) {
+
+	tests := []struct {
+		data   []byte
+		result DiscoveryAction
+	}{
+		{
+			data: []byte(`{
+			   "type": "Reachable",
+			   "peers": ["1.2.3.4", "2.3.4.5"]
+			 }`),
+			result: DiscoveryAction{Reachable: &Reachable{
+				Type:  "Reachable",
+				Peers: []string{"1.2.3.4", "2.3.4.5"},
+			}},
+		},
+		{
+			data: []byte(`{
+				   "type": "Unreachable",
+				   "peers": ["1.2.3.4", "2.3.4.5"]
+				 }`),
+			result: DiscoveryAction{Unreachable: &Unreachable{
+				Type:  "Unreachable",
+				Peers: []string{"1.2.3.4", "2.3.4.5"},
+			}},
+		},
+	}
+
+	for _, c := range tests {
+		var v DiscoveryAction
+		err := json.Unmarshal(c.data, &v)
+		assert.Nil(t, err)
+		assert.Equal(t, v, c.result)
+	}
+}

--- a/model_misbehavior_action.go
+++ b/model_misbehavior_action.go
@@ -43,8 +43,7 @@ func (dst *MisbehaviorAction) UnmarshalJSON(data []byte) error {
 	// try to unmarshal data into Ban
 	err = newStrictDecoder(data).Decode(&dst.Ban)
 	if err == nil {
-		jsonBan, _ := json.Marshal(dst.Ban)
-		if string(jsonBan) == "{}" { // empty struct
+		if dst.Ban == nil || dst.Ban.Type != "Ban" { // not the right type
 			dst.Ban = nil
 		} else {
 			match++
@@ -56,8 +55,7 @@ func (dst *MisbehaviorAction) UnmarshalJSON(data []byte) error {
 	// try to unmarshal data into Unban
 	err = newStrictDecoder(data).Decode(&dst.Unban)
 	if err == nil {
-		jsonUnban, _ := json.Marshal(dst.Unban)
-		if string(jsonUnban) == "{}" { // empty struct
+		if dst.Unban == nil || dst.Unban.Type != "Unban" { // not the right type
 			dst.Unban = nil
 		} else {
 			match++

--- a/model_misbehavior_action_test.go
+++ b/model_misbehavior_action_test.go
@@ -1,0 +1,44 @@
+package alephium
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalMisbehaviorAction(t *testing.T) {
+
+	tests := []struct {
+		data   []byte
+		result MisbehaviorAction
+	}{
+		{
+			data: []byte(`{
+			   "type": "Ban",
+			   "peers": ["1.2.3.4", "2.3.4.5"]
+			 }`),
+			result: MisbehaviorAction{Ban: &Ban{
+				Type:  "Ban",
+				Peers: []string{"1.2.3.4", "2.3.4.5"},
+			}},
+		},
+		{
+			data: []byte(`{
+				   "type": "Unban",
+				   "peers": ["1.2.3.4", "2.3.4.5"]
+				 }`),
+			result: MisbehaviorAction{Unban: &Unban{
+				Type:  "Unban",
+				Peers: []string{"1.2.3.4", "2.3.4.5"},
+			}},
+		},
+	}
+
+	for _, c := range tests {
+		var v MisbehaviorAction
+		err := json.Unmarshal(c.data, &v)
+		assert.Nil(t, err)
+		assert.Equal(t, v, c.result)
+	}
+}

--- a/model_output_test.go
+++ b/model_output_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUnmarshalModel(t *testing.T) {
+func TestUnmarshalOutput(t *testing.T) {
 
 	// Tx https://explorer-v112.testnet.alephium.org/transactions/d78e6b405f1e7239f660e11f08e9b20775dab396f617673e341ef1c41596167f
 	// is causing some unmarshalling error: "data matches more than one schema in oneOf(Output)"

--- a/model_peer_status.go
+++ b/model_peer_status.go
@@ -43,8 +43,7 @@ func (dst *PeerStatus) UnmarshalJSON(data []byte) error {
 	// try to unmarshal data into Banned
 	err = newStrictDecoder(data).Decode(&dst.Banned)
 	if err == nil {
-		jsonBanned, _ := json.Marshal(dst.Banned)
-		if string(jsonBanned) == "{}" { // empty struct
+		if dst.Banned == nil || dst.Banned.Type != "Banned" { // not the right type
 			dst.Banned = nil
 		} else {
 			match++
@@ -56,8 +55,7 @@ func (dst *PeerStatus) UnmarshalJSON(data []byte) error {
 	// try to unmarshal data into Penalty
 	err = newStrictDecoder(data).Decode(&dst.Penalty)
 	if err == nil {
-		jsonPenalty, _ := json.Marshal(dst.Penalty)
-		if string(jsonPenalty) == "{}" { // empty struct
+		if dst.Penalty == nil || dst.Penalty.Type != "Penalty" { // not the right type
 			dst.Penalty = nil
 		} else {
 			match++

--- a/model_peer_status_test.go
+++ b/model_peer_status_test.go
@@ -1,0 +1,44 @@
+package alephium
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalPeerStatus(t *testing.T) {
+
+	tests := []struct {
+		data   []byte
+		result PeerStatus
+	}{
+		{
+			data: []byte(`{
+			   "type": "Banned",
+			   "until": 1675580963000
+			 }`),
+			result: PeerStatus{Banned: &Banned{
+				Until: 1675580963000,
+				Type:  "Banned",
+			}},
+		},
+		{
+			data: []byte(`{
+				   "type": "Penalty",
+				   "value": 1234
+				 }`),
+			result: PeerStatus{Penalty: &Penalty{
+				Type:  "Penalty",
+				Value: 1234,
+			}},
+		},
+	}
+
+	for _, c := range tests {
+		var v PeerStatus
+		err := json.Unmarshal(c.data, &v)
+		assert.Nil(t, err)
+		assert.Equal(t, v, c.result)
+	}
+}


### PR DESCRIPTION
This PR fixes all the remaining oneOf buggy pattern in the generated code. The problem is when the objects have compatible fields, the unmarshalling works and the assertion "empty object {}" is invalid.
Tests have been added to ensure non regression in the future re-generation of the API.